### PR TITLE
[BE - BUG] - Fix the the bug when no accessToken

### DIFF
--- a/server/src/helper/token.helper.ts
+++ b/server/src/helper/token.helper.ts
@@ -14,8 +14,12 @@ config();
 // Getters
 export const getAccessToken = (req: Request) => {
   const headers = req.headers;
-  const authorization = headers?.authorization ?? null;
-  const accessToken = authorization?.replace("Bearer ", "") ?? null;
+  const authorization = headers.authorization;
+  const isNull =
+    typeof authorization === "string" && authorization === "null"
+      ? true
+      : false;
+  const accessToken = !isNull ? authorization?.replace("Bearer ", "") : null;
   return accessToken;
 };
 

--- a/server/src/helper/user.helper.ts
+++ b/server/src/helper/user.helper.ts
@@ -8,5 +8,5 @@ export const getCurrentUserRefreshToken = async (user_id: string) => {
     "select users.refresh_token from users where user_id = ?",
     user_id
   );
-  return user[0] ?? null;
+  return user[0]?.refresh_token ?? null;
 };


### PR DESCRIPTION
- [x] Assume that there's no `accessToken` stored in the `localStorage`. Then some parts of the page that is reliant to what's stored in the `localStorage` will display `null`.
- [x] To fix this, extract what's in the `refreshToken` or issue new `accessToken` and then set the `expiresIn` same as what's the `maxAge` set in the `refreshToken` cookie.
- [x] Do a test.

Issue Link: #36 

close: #36 